### PR TITLE
feat: add BaseTest class for Selenium WebDriver setup and teardown

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,7 @@
 Copilot chat instructions:
 - Limit expalnation to 1-2 sentences.
+- Use clear and concise language.
+- When providng examples for JAVA, use Google Java Style Guide.
 
 Copilot code review instructions:
-- When performing code review, respond in spanish.
-- If the code is correct, respond with "El código es correcto".
+- When reviewing code, ensure code adheres to Google Java Style Guide.

--- a/src/main/java/com/test09/base/BaseTest.java
+++ b/src/main/java/com/test09/base/BaseTest.java
@@ -1,0 +1,60 @@
+package com.test09.base;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Properties;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+public class BaseTest {
+    protected WebDriver driver;
+    protected Properties properties = new Properties();
+
+    @BeforeClass
+    public void setUpClass() {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("config.properties")) {
+            properties.load(input);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to load config.properties");
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        String browser = properties.getProperty("browser");
+        if ("chrome".equalsIgnoreCase(browser)) {
+            WebDriverManager.chromedriver().setup();
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments("--remote-allow-origins=*");
+            driver = new ChromeDriver(options);
+        } else if ("edge".equalsIgnoreCase(browser)) {
+            WebDriverManager.edgedriver().setup();
+            EdgeOptions options = new EdgeOptions();
+            options.addArguments("--remote-allow-origins=*");
+            driver = new EdgeDriver(options);
+        } else {
+            throw new IllegalArgumentException("Unsupported browser: " + browser);
+        }
+        driver.manage().window().maximize();
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+        driver.get(properties.getProperty("baseUrl"));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `BaseTest` class to centralize and standardize test setup and teardown for browser-based tests. The class handles loading configuration properties, initializing the appropriate WebDriver based on configuration, and managing browser sessions.

Test setup and configuration:

* Added new `BaseTest` class in `src/main/java/com/test09/base/BaseTest.java` to provide a common base for test classes, including setup and teardown logic.
* Loads configuration from `config.properties` to determine browser type and base URL for tests.

Browser initialization and management:

* Dynamically initializes either Chrome or Edge WebDriver based on configuration, using WebDriverManager for driver setup.
* Applies browser options and maximizes the window, with implicit wait configuration for improved test stability.
* Ensures proper cleanup of browser sessions after each test method.